### PR TITLE
Terraform scripts to deploy PDS Nucleus baseline system (minimum viable product) and a Registry use case

### DIFF
--- a/project-specific/dags/pds-registry-use-case.py
+++ b/project-specific/dags/pds-registry-use-case.py
@@ -39,7 +39,6 @@ with DAG(
     validate_data_2 = BashOperator(task_id='Validate_Data_2',
                                    bash_command='echo "Validate_Data"')
 
-
     # Copy config files and scripts from S3
     copy_configs_and_scripts_from_s3 = ECSOperator(
         task_id="Copy_Configs_And_Scripts",

--- a/project-specific/dags/pds-registry-use-case.py
+++ b/project-specific/dags/pds-registry-use-case.py
@@ -1,0 +1,124 @@
+# PDS Registry Load Use Case DAG
+#
+# This DAG is under development. This was just added as an example DAG for
+# Nucleus baseline deployment.
+
+import boto3
+from airflow import DAG
+from airflow.operators.bash import BashOperator
+from airflow.providers.amazon.aws.operators.ecs import ECSOperator
+from airflow.utils.dates import days_ago
+from airflow.utils.trigger_rule import TriggerRule
+
+# ECS configurations
+ECS_CLUSTER_NAME = "pds-nucleus-ecc-tf"
+ECS_LAUNCH_TYPE = "FARGATE"
+ECS_SUBNETS = ["<COMMA SEPARATED LIST OF SUBNETS>"]
+ECS_SECURITY_GROUPS = ["<COMMA SEPARATED LIST OF SECURITY GROUPS>"]
+ECS_AWS_LOGS_GROUP = "/ecs/pds-airflow-ecs-tf"
+
+with DAG(
+        dag_id="PDS_Registry_Use_Case",
+        schedule_interval=None,
+        catchup=False,
+        start_date=days_ago(1)
+) as dag:
+    client = boto3.client('ecs')
+
+    # Download data
+    download_data = BashOperator(task_id='Download_Data',
+                                 bash_command='echo "Download_Data"')
+
+    # Validate data 1 - This task is under development. This just added as
+    # an example DAG for Nucleus baseline deployment
+    validate_data_1 = BashOperator(task_id='Validate_Data_1',
+                                   bash_command='echo "Validate_Data"')
+
+    # Validate data 2 - This task is under development. This just added as
+    # an example DAG for Nucleus baseline deployment
+    validate_data_2 = BashOperator(task_id='Validate_Data_2',
+                                   bash_command='echo "Validate_Data"')
+
+
+    # Copy config files and scripts from S3
+    copy_configs_and_scripts_from_s3 = ECSOperator(
+        task_id="Copy_Configs_And_Scripts",
+        dag=dag,
+        cluster=ECS_CLUSTER_NAME,
+        task_definition="pds-s3-to-efs-data-move-terraform",
+        launch_type=ECS_LAUNCH_TYPE,
+        network_configuration={
+            "awsvpcConfiguration": {
+                "securityGroups": ECS_SECURITY_GROUPS,
+                "subnets": ECS_SUBNETS,
+            },
+        },
+        overrides={
+            "containerOverrides": [],
+        },
+        awslogs_group=ECS_AWS_LOGS_GROUP,
+        awslogs_stream_prefix="ecs/copy_configs_and_scripts"
+    )
+
+    # Registry Loader
+    harvest_and_load_data = ECSOperator(
+        task_id="Harvest_and_Load_Data",
+        dag=dag,
+        cluster=ECS_CLUSTER_NAME,
+        task_definition="pds-airflow-registry-loader-terraform",
+        launch_type=ECS_LAUNCH_TYPE,
+        network_configuration={
+            "awsvpcConfiguration": {
+                "securityGroups": ECS_SECURITY_GROUPS,
+                "subnets": ECS_SUBNETS,
+            },
+        },
+        overrides={
+            "containerOverrides": [],
+        },
+        awslogs_group=ECS_AWS_LOGS_GROUP,
+        awslogs_stream_prefix="ecs/reg loader"
+    )
+
+    # Execute integration tests
+    run_integration_tests = ECSOperator(
+        task_id="Execute_Integration_Tests",
+        dag=dag,
+        cluster=ECS_CLUSTER_NAME,
+        task_definition="pds-airflow-integration-test-terraform",
+        launch_type="FARGATE",
+        overrides={
+            "containerOverrides": [
+                {
+                    "name": "pds-airflow-integration-test-container",
+                    "command": ["run",
+                                "https://raw.githubusercontent.com/NASA-PDS"
+                                "/registry/main/docker/postman/"
+                                "postman_collection.json",
+                                "--env-var",
+                                "baseUrl=http://10.21.247.34:8080"],
+                },
+            ],
+        },
+        network_configuration={
+            "awsvpcConfiguration": {
+                "securityGroups": ECS_SECURITY_GROUPS,
+                "subnets": ECS_SUBNETS,
+            },
+        },
+        awslogs_group=ECS_AWS_LOGS_GROUP,
+        awslogs_stream_prefix="ecs/integration_tests"
+    )
+
+    # Print end date
+    print_end_date = BashOperator(
+        task_id='Print_End_Date',
+        bash_command='date',
+        trigger_rule=TriggerRule.ALL_DONE
+    )
+
+    # Workflow
+    copy_configs_and_scripts_from_s3 >> download_data
+    download_data >> validate_data_1 >> harvest_and_load_data
+    harvest_and_load_data >> run_integration_tests
+    run_integration_tests >> validate_data_2 >> print_end_date

--- a/project-specific/s3-to-efs/Dockerfile
+++ b/project-specific/s3-to-efs/Dockerfile
@@ -1,0 +1,13 @@
+FROM ubuntu:18.04
+
+RUN apt-get update && apt-get install -y curl && apt-get install -y unzip && apt-get install -y sudo && apt-get install -y nfs-common
+
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && unzip awscliv2.zip && ./aws/install
+
+RUN rm -rf aws && rm awscliv2.zip
+
+ADD data-prep.sh /
+
+RUN chmod +x /data-prep.sh
+
+CMD ["/bin/bash", "-c", "/data-prep.sh"]

--- a/project-specific/s3-to-efs/README.md
+++ b/project-specific/s3-to-efs/README.md
@@ -1,0 +1,19 @@
+# Docker image to copy config files and scripts from an S3 bucket to EFS
+
+The files in this directory builds a docker image which is used to
+copy config files and scripts from an S3 bucket to EFS.
+
+This docker image will be pushed to the AWS ECR and then it will be
+used by an ECS task.
+
+## Steps to build and push the docker image to ECR
+
+1. Go to [AWS ECR](https://us-west-2.console.aws.amazon.com/ecr/repositories?region=us-west-2).
+2. Create a new repository called `pds-s3-to-efs-copy` or make sure if there is a 
+repository available with the name `pds-s3-to-efs-copy`.
+3. Click on the repository name `pds-s3-to-efs-copy`.
+4. View Push Commands and note the push command for your operating system.
+5. Open a terminal window and change directory to the directory containing the Dockerfile 
+(same directory which contains this README file).
+6. Execute Push Commands to push the docker image to the `pds-s3-to-efs-copy` 
+repository on AWS ECR.

--- a/project-specific/s3-to-efs/data-prep.sh
+++ b/project-specific/s3-to-efs/data-prep.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+aws s3 cp s3://nucleus-airflow-dags-bucket/staging/default-config/ /def-cfg/ --recursive
+aws s3 cp s3://nucleus-airflow-dags-bucket/staging/scripts/ /usr/local/bin/ --recursive

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,97 @@
+# PDS Nucleus Baseline Deployment
+
+The Terraform scripts in this directory deploy a minimum viable product (MVP) of PDS Nucleus data pipeline
+system on AWS Cloud. Currently, Nucleus is based on Amazon Managed Workflows for Apache Airflow (MWAA).
+Therefore, as a result of the Terraform scripts in this directory following things will be created.
+- AWS Security Group for MWAA
+- AWS S3 Bucket with relevant bucket policies to keep Airflow DAG files and Python requirements file
+- Dags directory in S# bucket to keep Airflow DAG files
+- Python requirements.txt file to introduce the additional Python packages required by DAGs
+- Amazon Managed Workflows for Apache Airflow (MWAA)
+
+
+Note: In addition to the above components, there are Terraform modules, container definitions and a DAG file
+included to deploy PDS Registry related ECS tasks, a DAG and an EFS file system that can be used to demonstrate 
+an example PDS Registry use case. However, these additional components are not part of the MVP of 
+PDS Nucleus data pipeline. These PDS Registry related terraform modules are still under development (not part of the PDS Nucleus Baseline Deployment task)
+and are kept disabled in the main.tf terraform file.
+
+
+## Prerequisites to Deploy Nucleus Baseline System
+
+1. An AWS Account with permissions to deploy following AWS services
+   - Amazon Managed Workflows for Apache Airflow (MWAA)
+   - AWS Security Groups
+   - AWS S3 Bucket with relevant bucket policies
+   - ECS Cluster and ECS Tasks
+   - EFS File System
+   - ECR (at least readonly access)
+
+2. Ability to get AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY and AWS_SESSION_TOKEN for the AWS account
+
+3. Terraform is installed in local environment (This was tested with Terraform v1.3.7. Any higher version should also work)
+ - Instructions to install Terraform is available at https://developer.hashicorp.com/terraform/tutorials/aws-get-started/install-cli 
+
+4. A VPC and one or more subnets should be available on AWS (obtain the VPC ID and subnet IDs from AWS console or from the AWS
+system admin team of your AWS account)
+
+
+## Steps to Deploy the PDS Nucleus Baseline System
+
+1. Checkout the https://github.com/NASA-PDS/nucleus repository.
+
+```shell
+git clone https://github.com/NASA-PDS/nucleus.git
+```
+
+2. Open a terminal and change current working directory to the `nucleus/terraform` directory.
+
+```shell
+cd nucleus/terraform
+```
+
+3. Set following environment variables in terminal window
+    - AWS_ACCESS_KEY_ID
+    - AWS_SECRET_ACCESS_KEY
+    - AWS_SESSION_TOKEN
+    - AWS_DEFAULT_REGION
+
+4. Open the `variables.tf` file at `nucleus/terraform/terraform-modules/mwaa-env/variables.tf` and
+update the following variables to match with your AWS Setup. Most of the below values can be obtained by
+the system admin team of your AWS account.
+
+    - vpc_id:  VPC ID of your AWS VPC
+    - vpc_cidr: VPC CIDR for MWAA (E.g.: "10.1.0.0/16")
+    - nucleus_security_group_ingress_cidr: List of ingress CIDRs for the Nucleus Security Group to be created (E.g.: "10.21.240.0/20")
+    - subnet_ids: List of Subnet IDs to be used for the MWAA
+    - airflow_execution_role: Airflow AWS Execution Role
+
+5. Initialize Terraform working directory.
+
+```shell
+terraform init
+```
+
+6. [Optional] Check the Terraform plan to see the changes to be applied.
+
+```shell
+terraform plan
+```
+
+7. Deploy Nucleus baseline system using Terraform apply.
+
+```shell
+terraform apply
+```
+
+8. Login to the AWS Console with your AWS Account.
+
+9. Make sure that the correct AWS Region is selected and search for "Managed Apache Airflow".
+
+10. Visit the "Managed Apache Airflow" (Amazon MWAA) page and check the list of environments.
+
+11. Find the relevant Amazon MWAA environment (Default name: PDS-Nucleus-Airflow-Env) and click on
+    Open Airflow UI link to open the Airflow UI.
+
+12. The DAGs can be added to the Airflow by uploading Airflow DAG files to the DAG folder of S3 bucket
+configured in the `mwaa_env.tf` file (Default S3 Bucket name: nucleus-airflow-dags-bucket).

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,17 @@
+# The Terraform module to create the PDS Nucleus Baseline System (without any project specific components)
+module "mwaa-env" {
+  source = "./terraform-modules/mwaa-env"
+}
+
+
+# The following modules are specific to PDS Registry and are under development. These modules are currently
+# capable of successfully deploying some ECS tasks related with PDS Registry. However, these modules
+# are currently disabled to keep the PDS Nucleus Baseline System clean and to avoid confusions.
+
+#module "efs" {
+#  source = "./terraform-modules/efs"
+#}
+#
+#module "ecs" {
+#  source = "./terraform-modules/ecs"
+#}

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}

--- a/terraform/terraform-modules/ecs/container-definitions/pds-airflow-integration-test-containers.json
+++ b/terraform/terraform-modules/ecs/container-definitions/pds-airflow-integration-test-containers.json
@@ -1,0 +1,33 @@
+[
+    {
+        "name": "pds-airflow-integration-test-container",
+        "image": "<ACCOUNT_ID>.dkr.ecr.us-west-2.amazonaws.com/pds-airflow-int-test:latest",
+        "cpu": 0,
+        "memory": 128,
+        "portMappings": [],
+        "essential": true,
+        "entryPoint": [],
+        "command": [],
+        "environment": [
+            {
+                "name": "REG_API_URL",
+                "value": "http://10.21.247.34:8080"
+            }
+        ],
+        "mountPoints": [
+            {
+                "sourceVolume": "pds-airflow-efs-registry-loader-default-configs",
+                "containerPath": "/def-cfg/"
+            }
+        ],
+        "volumesFrom": [],
+        "logConfiguration": {
+            "logDriver": "awslogs",
+            "options": {
+                "awslogs-group": "/ecs/pds-airflow-integration-test-2",
+                "awslogs-region": "us-west-2",
+                "awslogs-stream-prefix": "ecs"
+            }
+        }
+    }
+]

--- a/terraform/terraform-modules/ecs/container-definitions/pds-airflow-registry-loader-containers.json
+++ b/terraform/terraform-modules/ecs/container-definitions/pds-airflow-registry-loader-containers.json
@@ -1,0 +1,50 @@
+[
+    {
+        "name": "pds-airflow-registry-loader",
+        "image": "<ACCOUNT_ID>.dkr.ecr.us-west-2.amazonaws.com/pds-airflow-registry-loader:latest",
+        "cpu": 0,
+        "memoryReservation": 500,
+        "portMappings": [],
+        "essential": true,
+        "entryPoint": [],
+        "command": [],
+        "environment": [
+            {
+                "name": "ES_URL",
+                "value": "https://10.21.247.34:9200/"
+            },
+            {
+                "name": "TEST_DATA_LIDVID",
+                "value": "urn:nasa:pds:insight_rad::2.1"
+            },
+            {
+                "name": "RUN_TESTS",
+                "value": "true"
+            },
+            {
+                "name": "TEST_DATA_URL",
+                "value": "https://pds-gamma.jpl.nasa.gov/data/pds4/test-data/registry/urn-nasa-pds-insight_rad.tar.gz"
+            }
+        ],
+        "mountPoints": [
+            {
+                "sourceVolume": "pds-airflow-efs-registry-loader-scripts",
+                "containerPath": "/usr/local/bin/",
+                "readOnly": false
+            },
+            {
+                "sourceVolume": "pds-airflow-efs-registry-loader-default-configs",
+                "containerPath": "/def-cfg/"
+            }
+        ],
+        "volumesFrom": [],
+        "logConfiguration": {
+            "logDriver": "awslogs",
+            "options": {
+                "awslogs-group": "/ecs/pds-airflow-registry-loader",
+                "awslogs-region": "us-west-2",
+                "awslogs-stream-prefix": "ecs"
+            }
+        }
+    }
+]

--- a/terraform/terraform-modules/ecs/container-definitions/pds-s3-to-efs-data-mover.json
+++ b/terraform/terraform-modules/ecs/container-definitions/pds-s3-to-efs-data-mover.json
@@ -1,0 +1,50 @@
+[
+    {
+        "name": "pds-s3-to-efs-data-mover",
+        "image": "<ACCOUNT_ID>.dkr.ecr.us-west-2.amazonaws.com/pds-s3-to-efs-copy:latest",
+        "cpu": 0,
+        "memoryReservation": 500,
+        "portMappings": [],
+        "essential": true,
+        "entryPoint": [],
+        "command": [],
+        "environment": [
+            {
+                "name": "ES_URL",
+                "value": "https://10.21.247.34:9200/"
+            },
+            {
+                "name": "TEST_DATA_LIDVID",
+                "value": "urn:nasa:pds:insight_rad::2.1"
+            },
+            {
+                "name": "RUN_TESTS",
+                "value": "true"
+            },
+            {
+                "name": "TEST_DATA_URL",
+                "value": "https://pds-gamma.jpl.nasa.gov/data/pds4/test-data/registry/urn-nasa-pds-insight_rad.tar.gz"
+            }
+        ],
+        "mountPoints": [
+            {
+                "sourceVolume": "pds-airflow-efs-registry-loader-scripts",
+                "containerPath": "/usr/local/bin/",
+                "readOnly": false
+            },
+            {
+                "sourceVolume": "pds-airflow-efs-registry-loader-default-configs",
+                "containerPath": "/def-cfg/"
+            }
+        ],
+        "volumesFrom": [],
+        "logConfiguration": {
+            "logDriver": "awslogs",
+            "options": {
+                "awslogs-group": "/ecs/pds-s3-to-efs-data-mover",
+                "awslogs-region": "us-west-2",
+                "awslogs-stream-prefix": "ecs"
+            }
+        }
+    }
+]

--- a/terraform/terraform-modules/ecs/ecs.tf
+++ b/terraform/terraform-modules/ecs/ecs.tf
@@ -1,0 +1,146 @@
+# Terraform script to create the use case specific ECS task definitions
+
+resource "aws_ecs_cluster" "main" {
+  name = "pds-nucleus-ecc-tf"
+}
+
+resource "aws_ecs_task_definition" "pds-s3-to-efs-data-move-terraform" {
+  family                   = "pds-s3-to-efs-data-move-terraform"
+  requires_compatibilities = ["EC2", "FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = 4096
+  memory                   = 8192
+  runtime_platform {
+    operating_system_family = "LINUX"
+  }
+
+  volume {
+    name = "pds-airflow-efs-registry-loader-scripts"
+
+    efs_volume_configuration {
+      file_system_id     = var.efs_file_system_id
+      root_directory     = "/"
+      transit_encryption = "ENABLED"
+      authorization_config {
+        access_point_id = var.registry_loader_scripts_access_point_id
+        iam             = "ENABLED"
+      }
+    }
+  }
+
+  volume {
+    name = "pds-airflow-efs-registry-loader-default-configs"
+
+    efs_volume_configuration {
+      file_system_id     = var.efs_file_system_id
+      root_directory     = "/"
+      transit_encryption = "ENABLED"
+      authorization_config {
+        access_point_id = var.registry_loader_default_configs_access_point_id
+        iam             = "ENABLED"
+      }
+    }
+  }
+
+  container_definitions = file("terraform-modules/ecs/container-definitions/pds-s3-to-efs-data-mover.json")
+  task_role_arn         = var.task_role_arn
+  execution_role_arn    = var.execution_role_arn
+
+}
+
+resource "aws_ecs_task_definition" "pds-airflow-registry-loader-terraform" {
+  family                   = "pds-airflow-registry-loader-terraform"
+  requires_compatibilities = ["EC2", "FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = 4096
+  memory                   = 8192
+  runtime_platform {
+    operating_system_family = "LINUX"
+  }
+
+  volume {
+    name = "pds-airflow-efs-registry-loader-scripts"
+
+    efs_volume_configuration {
+      file_system_id     = var.efs_file_system_id
+      root_directory     = "/"
+      transit_encryption = "ENABLED"
+      authorization_config {
+        access_point_id = var.registry_loader_scripts_access_point_id
+        iam             = "ENABLED"
+      }
+    }
+  }
+
+  volume {
+    name = "pds-airflow-efs-registry-loader-default-configs"
+
+    efs_volume_configuration {
+      file_system_id     = var.efs_file_system_id
+      root_directory     = "/"
+      transit_encryption = "ENABLED"
+      authorization_config {
+        access_point_id = var.registry_loader_default_configs_access_point_id
+        iam             = "ENABLED"
+      }
+    }
+  }
+
+  container_definitions = file("terraform-modules/ecs/container-definitions/pds-airflow-registry-loader-containers.json")
+  task_role_arn         = var.task_role_arn
+  execution_role_arn    = var.execution_role_arn
+
+}
+
+resource "aws_ecs_task_definition" "pds-airflow-integration-test-terraform" {
+  family                   = "pds-airflow-integration-test-terraform"
+  requires_compatibilities = ["EC2", "FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = 4096
+  memory                   = 8192
+  runtime_platform {
+    operating_system_family = "LINUX"
+  }
+
+  volume {
+    name = "pds-airflow-efs"
+
+    efs_volume_configuration {
+      file_system_id     = var.efs_file_system_id
+      root_directory     = "/"
+      transit_encryption = "DISABLED"
+    }
+  }
+
+  volume {
+    name = "pds-airflow-efs-registry-loader-scripts"
+
+    efs_volume_configuration {
+      file_system_id     = var.efs_file_system_id
+      root_directory     = "/"
+      transit_encryption = "ENABLED"
+      authorization_config {
+        access_point_id = var.registry_loader_scripts_access_point_id
+        iam             = "ENABLED"
+      }
+    }
+  }
+
+  volume {
+    name = "pds-airflow-efs-registry-loader-default-configs"
+
+    efs_volume_configuration {
+      file_system_id     = var.efs_file_system_id
+      root_directory     = "/"
+      transit_encryption = "ENABLED"
+      authorization_config {
+        access_point_id = var.registry_loader_default_configs_access_point_id
+        iam             = "ENABLED"
+      }
+    }
+  }
+
+  container_definitions = file("terraform-modules/ecs/container-definitions/pds-airflow-integration-test-containers.json")
+  task_role_arn         = var.task_role_arn
+  execution_role_arn    = var.execution_role_arn
+}

--- a/terraform/terraform-modules/ecs/variables.tf
+++ b/terraform/terraform-modules/ecs/variables.tf
@@ -1,0 +1,29 @@
+variable "efs_file_system_id" {
+  type        = string
+  description = "EFS File System ID"
+  default     = "<EFS File System ID>"
+}
+
+variable "registry_loader_scripts_access_point_id" {
+  type        = string
+  description = "Registry Loader Scripts EFS Access Point ID"
+  default     = "<Registry Loader Scripts EFS Access Point ID>"
+}
+
+variable "registry_loader_default_configs_access_point_id" {
+  type        = string
+  description = "Registry Loader Default Configs EFS Access Point ID"
+  default     = "<Registry Loader Default Configs EFS Access Point ID>"
+}
+
+variable "task_role_arn" {
+  type        = string
+  description = "Airflow Task Role ARN"
+  default     = "<Airflow Task Role ARN>"
+}
+
+variable "execution_role_arn" {
+  type        = string
+  description = "Airflow Execution Role ARN"
+  default     = "<Airflow Execution Role ARN>"
+}

--- a/terraform/terraform-modules/efs/efs.tf
+++ b/terraform/terraform-modules/efs/efs.tf
@@ -1,0 +1,61 @@
+# Terraform script to create a EFS file system to be used for file exchange between containers
+
+resource "aws_efs_file_system" "nucleus_efs" {
+  creation_token = "nucleus_efs_token"
+
+  tags = {
+    Name = "Nucleus"
+  }
+}
+
+resource "aws_efs_access_point" "root" {
+
+  file_system_id = aws_efs_file_system.nucleus_efs.id
+
+  root_directory {
+    path = "/"
+  }
+
+  tags = {
+    Name = "root access point"
+  }
+}
+
+resource "aws_efs_access_point" "scripts" {
+
+  file_system_id = aws_efs_file_system.nucleus_efs.id
+
+  root_directory {
+    path = "/registry/docker/scripts"
+  }
+
+  tags = {
+    Name = "scripts access point"
+  }
+}
+
+resource "aws_efs_access_point" "registry-loader-waits-for-elasticsearch" {
+
+  file_system_id = aws_efs_file_system.nucleus_efs.id
+
+  root_directory {
+    path = "/registry/docker/scripts/registry-loader-waits-for-elasticsearch.sh"
+  }
+
+  tags = {
+    Name = "registry-loader-waits-for-elasticsearch access point"
+  }
+}
+
+resource "aws_efs_access_point" "default-config" {
+
+  file_system_id = aws_efs_file_system.nucleus_efs.id
+
+  root_directory {
+    path = "/registry/docker/default-config"
+  }
+
+  tags = {
+    Name = "default-config access point"
+  }
+}

--- a/terraform/terraform-modules/mwaa-env/mwaa_env.tf
+++ b/terraform/terraform-modules/mwaa-env/mwaa_env.tf
@@ -1,0 +1,119 @@
+# Terraform script to create the baseline MWAA environment for Nucleus
+
+resource "aws_security_group" "nucleus_security_group" {
+  name        = "nucleus_security_group"
+  description = "nucleus_security_group"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    description = "All traffic"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = var.nucleus_security_group_ingress_cidr
+  }
+
+  egress {
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+}
+
+resource "aws_s3_bucket" "nucleus_airflow_dags_bucket" {
+  bucket = "nucleus-airflow-dags-bucket"
+
+  tags = {
+    Name        = "Nucleus Airflow DAGS bucket terraform"
+    Environment = "Dev"
+  }
+
+  force_destroy = true
+}
+
+resource "aws_s3_bucket_object" "dags" {
+  bucket        = aws_s3_bucket.nucleus_airflow_dags_bucket.id
+  acl           = "private"
+  key           = "dags/"
+  source        = "/dev/null"
+  force_destroy = true
+  depends_on    = [aws_s3_bucket.nucleus_airflow_dags_bucket]
+}
+
+resource "aws_s3_bucket_object" "requirements" {
+
+  bucket        = aws_s3_bucket.nucleus_airflow_dags_bucket.id
+  key           = "requirements.txt"
+  acl           = "private" # or can be "public-read"
+  force_destroy = true
+  source        = "./terraform-modules/mwaa-env/requirements.txt"
+}
+
+resource "aws_s3_bucket_public_access_block" "nucleus_airflow_dags_bucket_public_access_block" {
+  bucket = aws_s3_bucket.nucleus_airflow_dags_bucket.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_policy" "allow_access_from_another_account" {
+  bucket = aws_s3_bucket.nucleus_airflow_dags_bucket.id
+  policy = data.aws_iam_policy_document.allow_access_from_another_account.json
+}
+
+data "aws_iam_policy_document" "allow_access_from_another_account" {
+  statement {
+    principals {
+      type        = "AWS"
+      identifiers = [var.airflow_execution_role]
+    }
+
+    actions = [
+      "s3:*"
+    ]
+
+    effect = "Allow"
+
+    resources = [
+      aws_s3_bucket.nucleus_airflow_dags_bucket.arn,
+      "${aws_s3_bucket.nucleus_airflow_dags_bucket.arn}/*",
+    ]
+  }
+}
+
+resource "aws_mwaa_environment" "pds_nucleus_airflow_env" {
+
+  name              = var.airflow_env_name
+  airflow_version   = var.airflow_version
+  environment_class = var.airflow_env_class
+
+  dag_s3_path        = var.airflow_dags_path
+  execution_role_arn = var.airflow_execution_role
+
+  requirements_s3_path = var.airflow_requirements_path
+
+  depends_on = [aws_s3_bucket_object.dags, aws_security_group.nucleus_security_group]
+
+  min_workers           = 1
+  max_workers           = 25
+  webserver_access_mode = "PUBLIC_ONLY"
+
+  network_configuration {
+    security_group_ids = [aws_security_group.nucleus_security_group.id]
+    subnet_ids         = var.subnet_ids
+  }
+
+  source_bucket_arn = aws_s3_bucket.nucleus_airflow_dags_bucket.arn
+
+  airflow_configuration_options = {
+    "core.load_default_connections" = "false"
+    "core.load_examples"            = "false"
+    "webserver.dag_default_view"    = "tree"
+    "webserver.dag_orientation"     = "TB"
+    "logging.logging_level"         = "INFO"
+  }
+}

--- a/terraform/terraform-modules/mwaa-env/requirements.txt
+++ b/terraform/terraform-modules/mwaa-env/requirements.txt
@@ -1,0 +1,2 @@
+apache-airflow-providers-docker==3.1.0
+apache-airflow-providers-amazon==2.4.3

--- a/terraform/terraform-modules/mwaa-env/variables.tf
+++ b/terraform/terraform-modules/mwaa-env/variables.tf
@@ -1,0 +1,71 @@
+variable "airflow_env_name" {
+  description = "PDS Nucleus Airflow Env Name"
+  default     = "PDS-Nucleus-Airflow-Env"
+  type        = string
+}
+
+variable "airflow_version" {
+  description = "PDS Nucleus Airflow Version"
+  default     = "2.2.2"
+  type        = string
+}
+
+variable "airflow_env_class" {
+  description = "PDS Nucleus Airflow Environment Class"
+  default     = "mw1.medium"
+  type        = string
+}
+
+variable "airflow_dags_path" {
+  description = "PDS Nucleus Airflow DAGs Path"
+  default     = "dags/"
+  type        = string
+}
+
+variable "airflow_requirements_path" {
+  description = "PDS Nucleus Airflow Python Requirements File Path"
+  default     = "dags/"
+  type        = string
+}
+
+variable "region" {
+  description = "region"
+  type        = string
+  default     = "us-west-2"
+}
+
+variable "tags" {
+  description = "Default tags"
+  default     = {"env": "dev"}
+  type        = map(string)
+}
+
+variable "vpc_id" {
+  description = "VPC ID"
+  type        = string
+  default     = "<VPC ID>"
+}
+
+variable "vpc_cidr" {
+  description = "VPC CIDR for MWAA"
+  type        = string
+  default     = "<VPC CIDR>"
+}
+
+variable "nucleus_security_group_ingress_cidr" {
+  description = "Ingress CIDR for Nucleus Security Group"
+  type        = list
+  default     = ["<Ingress CIDR>"]
+}
+
+variable "subnet_ids" {
+  description = "Subnet IDs"
+  type = list
+  default = ["<COMMA SEPERATED LIST OF SUBNET IDs>"]
+}
+
+variable "airflow_execution_role" {
+  description = "Airflow AWS Execution Role"
+  type = string
+  default = "<Airflow AWS Execution Role>"
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,5 @@
+variable "region" {
+  type        = string
+  description = "Region"
+  default     = "us-west-2"
+}


### PR DESCRIPTION
## 🗒️ Summary
The Terraform scripts in this pull request deploy a minimum viable product (MVP) of PDS Nucleus data pipeline
system on AWS Cloud. Currently, Nucleus is based on Amazon Managed Workflows for Apache Airflow (MWAA).
Therefore, as a result of the Terraform scripts in this directory following things will be created.

- AWS Security Group for MWAA
- AWS S3 Bucket with relevant bucket policies to keep Airflow DAG files and Python requirements file
- Dags directory in S3 bucket to keep Airflow DAG files
- Python requirements.txt file to introduce the additional Python packages required by DAGs
- Amazon Managed Workflows for Apache Airflow (MWAA)

Note: In addition to the above components, there are Terraform modules, container definitions and a DAG file ncluded to deploy PDS Registry related ECS tasks, a DAG and an EFS file system that can be used to demonstrate an example PDS Registry use case. However, these additional components are not part of the MVP of PDS Nucleus data pipeline. These PDS Registry related terraform modules are still under development (not part of the PDS Nucleus Baseline Deployment task) and are kept disabled in the main.tf terraform file.

## ♻️ Related Issues

NASA-PDS/nucleus#22 [As a user, I want to deploy a baseline nucleus automatically](https://github.com/nasa-pds/nucleus/issues/22)

NASA-PDS/nucleus#24 [As a user, I want to configure a nucleus pipeline](https://github.com/nasa-pds/nucleus/issues/24)