### PR TITLE
disabled terraform workflow

### DIFF
--- a/.github/workflows/terraform-cicd.yaml
+++ b/.github/workflows/terraform-cicd.yaml
@@ -1,11 +1,9 @@
 name: 'Terraform-Workflow'
 
+#Currently this workflow is disabled since resources were already deployed manually in NGAP.
+
 on:
-  push:
-    branches:
-      - '**'
-  pull_request:
-    types: [opened, edited, reopened, ready_for_review, review_requested]
+  # push:
   workflow_dispatch:
 
 permissions:
@@ -50,7 +48,6 @@ jobs:
 
     - name: Terraform Plan
       id: plan
-      if: github.event_name == 'push' || github.event_name == 'pull_request'
       env:
         TF_VAR_efs_file_system_id: "${{ secrets.EFS_FILE_SYSTEM_ID }}"
         TF_VAR_registry_loader_scripts_access_point_id: "${{ secrets.REGISTRY_LOADER_SCRIPTS_ACCESS_POINT_ID }}"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -9,7 +9,6 @@ module "mwaa-env" {
   airflow_execution_role              = var.airflow_execution_role
 }
 
-
 # The following modules are specific to PDS Registry and are under development. These modules are currently
 # capable of successfully deploying some ECS tasks related with PDS Registry. However, these modules
 # are currently disabled to keep the PDS Nucleus Baseline System clean and to avoid confusions.
@@ -18,12 +17,12 @@ module "mwaa-env" {
 #   source = "./terraform-modules/efs"
 # }
 
-module "ecs" {
-  source = "./terraform-modules/ecs"
+# module "ecs" {
+#   source = "./terraform-modules/ecs"
 
-  efs_file_system_id                              = var.efs_file_system_id
-  registry_loader_scripts_access_point_id         = var.registry_loader_scripts_access_point_id
-  registry_loader_default_configs_access_point_id = var.registry_loader_default_configs_access_point_id
-  task_role_arn                                   = var.task_role_arn
-  execution_role_arn                              = var.execution_role_arn
-}
+#   efs_file_system_id                              = var.efs_file_system_id
+#   registry_loader_scripts_access_point_id         = var.registry_loader_scripts_access_point_id
+#   registry_loader_default_configs_access_point_id = var.registry_loader_default_configs_access_point_id
+#   task_role_arn                                   = var.task_role_arn
+#   execution_role_arn                              = var.execution_role_arn
+# }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -63,3 +63,4 @@ variable "execution_role_arn" {
   description = "Airflow Execution Role ARN"
   sensitive   = true
 }
+


### PR DESCRIPTION
## 🗒️ Summary
Since all nucleus resources are already deployed to NGAP, terraform workflow has been disabled to avoid merging errors.

## ⚙️ Test Data and/or Report
One of the following should be included here:
* Reference to regression test included in code (preferred wherever reasonable)
* Attach test data here + outputs of tests

## ♻️ Related Issues
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
-->

Ref - https://github.com/NASA-PDS/operations/issues/367
