### PR TITLE
ADD changes to use a user-friendly URL for Nucleus Auth ALB

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -111,6 +111,7 @@ Note:  Examples of `terraform.tfvars` files are available at `terraform/variable
     - cognito_user_pool_id : The ID of the Cognito user pool which is used to create Nuclues user accounts
     - cognito_user_pool_domain : Cognitp domain name of the Cognito user pool which is sued to create Nuclues user accounts
     - auth_alb_listener_certificate_arn : ARN of the certificate to be used for the ALB Listener facing Airflow UI
+    - nucleus_cloudfront_origin_hostname : Hostname of the Nucleus Cloudfront origin (E.g: pds-sit.mcp.nasa.gov)
     - aws_elb_account_id_for_the_region : The standard ELB account ID for the AWS region. For US West (Oregon), this is  797873946194. Read more at https://docs.aws.amazon.com/elasticloadbalancing/latest/application/enable-access-logging.html)
 
 
@@ -151,10 +152,11 @@ pds_shared_logs_bucket_name                  = "pds-logs-dev"
 pds_nucleus_default_airflow_dag_id      = "pds-basic-registry-load-use-case"
 pds_nucleus_s3_backlog_processor_dag_id = "pds-nucleus-s3-backlog-processor"
  
-cognito_user_pool_id              = "us-west-2_ABCDEFG"
-cognito_user_pool_domain          = "pds-registry"
-auth_alb_listener_certificate_arn = "arn:aws:acm:us-west-2:123456789:certificate/ca123456-abcd-abcd-1234-abcdefghi"
-aws_elb_account_id_for_the_region = "797873946194"
+cognito_user_pool_id               = "us-west-2_ABCDEFG"
+cognito_user_pool_domain           = "pds-registry"
+auth_alb_listener_certificate_arn  = "arn:aws:acm:us-west-2:123456789:certificate/ca123456-abcd-abcd-1234-abcdefghi"
+nucleus_cloudfront_origin_hostname = "pds-sit.mcp.nasa.gov"
+aws_elb_account_id_for_the_region  = "797873946194"
 
 ```
 
@@ -192,7 +194,7 @@ Example:
 ```shell
 Outputs:
 
-pds_nucleus_airflow_ui_url = "https://pds-nucleus-12345678.us-west-2.elb.amazonaws.com:4443/aws_mwaa/aws-console-sso"
+pds_nucleus_airflow_ui_url = "https://pds-nucleus-12345678.us-west-2.elb.amazonaws.com/aws_mwaa/aws-console-sso"
 ```
 
 11. Login to the AWS Console with your AWS Account.
@@ -225,7 +227,7 @@ Example:
 ```shell
 Outputs:
 
-pds_nucleus_airflow_ui_url = "https://pds-nucleus-12345678.us-west-2.elb.amazonaws.com:4443/aws_mwaa/aws-console-sso"
+pds_nucleus_airflow_ui_url = "https://pds-nucleus-12345678.us-west-2.elb.amazonaws.com/aws_mwaa/aws-console-sso"
 ```
 
 3. Use the Cognito username and password to login.

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -177,6 +177,7 @@ module "cognito-auth" {
   auth_alb_name                                  = var.auth_alb_name
   auth_alb_subnet_ids                            = var.auth_alb_subnet_ids
   auth_alb_listener_certificate_arn              = var.auth_alb_listener_certificate_arn
+  nucleus_cloudfront_origin_hostname             = var.nucleus_cloudfront_origin_hostname
   cognito_user_pool_domain                       = var.cognito_user_pool_domain
   cognito_user_pool_id                           = var.cognito_user_pool_id
   aws_elb_account_id_for_the_region              = var.aws_elb_account_id_for_the_region
@@ -191,6 +192,6 @@ module "cognito-auth" {
 }
 
 # Output the ALB URL for Airflow UI
-output "pds_nucleus_airflow_ui_url" {
-  value = nonsensitive(module.cognito-auth.pds_nucleus_airflow_ui_url)
+output "pds_nucleus_airflow_ui_urls" {
+  value = nonsensitive(module.cognito-auth.pds_nucleus_airflow_ui_urls)
 }

--- a/terraform/terraform-modules/cognito-auth/cognito-auth.tf
+++ b/terraform/terraform-modules/cognito-auth/cognito-auth.tf
@@ -160,7 +160,7 @@ resource "aws_cognito_user_pool_client" "cognito_user_pool_client_for_mwaa" {
   name                                 = "pds-nucleus-airflow-ui-client"
   user_pool_id                         = data.aws_cognito_user_pool.cognito_user_pool.id
   generate_secret                      = true
-  callback_urls                        = ["https://${aws_lb.pds_nucleus_auth_alb.dns_name}:${var.auth_alb_listener_port}/oauth2/idpresponse"]
+  callback_urls                        = ["https://${aws_lb.pds_nucleus_auth_alb.dns_name}/oauth2/idpresponse", "https://${var.nucleus_cloudfront_origin_hostname}/oauth2/idpresponse"]
   allowed_oauth_flows_user_pool_client = true
   allowed_oauth_flows                  = ["code"]
   allowed_oauth_scopes                 = ["email", "openid"]
@@ -199,6 +199,6 @@ resource "aws_cognito_user_group" "pds_nucleus_viewer_cognito_user_group" {
 
 
 
-output "pds_nucleus_airflow_ui_url" {
-  value = "https://${aws_lb.pds_nucleus_auth_alb.dns_name}:${var.auth_alb_listener_port}/aws_mwaa/aws-console-sso"
+output "pds_nucleus_airflow_ui_urls" {
+  value = ["https://${aws_lb.pds_nucleus_auth_alb.dns_name}/aws_mwaa/aws-console-sso", "https://${var.nucleus_cloudfront_origin_hostname}/nucleus"]
 }

--- a/terraform/terraform-modules/cognito-auth/lambda/package/pds_nucleus_alb_auth.py
+++ b/terraform/terraform-modules/cognito-auth/lambda/package/pds_nucleus_alb_auth.py
@@ -70,7 +70,7 @@ def lambda_handler(event, context):
             logger.error("Invalid token")
             return close(headers, "Unauthorized", status_code=401)
 
-        if path == '/aws_mwaa/aws-console-sso':
+        if path.lower().startswith('/nucleus') or path == '/aws_mwaa/aws-console-sso':
             redirect = login(headers=headers, query_params=query_params, user_claims=user_claims, iam_role_arn=iam_role_arn)
         else:
             redirect = close(headers, f"Bad request: {path}, {query_params}, {headers}", status_code=400)

--- a/terraform/terraform-modules/cognito-auth/variables.tf
+++ b/terraform/terraform-modules/cognito-auth/variables.tf
@@ -34,6 +34,11 @@ variable "auth_alb_listener_certificate_arn" {
   sensitive   = true
 }
 
+variable "nucleus_cloudfront_origin_hostname" {
+  description = "Hostname of the Nucleus Cloudfront origin (E.g: pds-sit.mcp.nasa.gov)"
+  type        = string
+}
+
 variable "aws_elb_account_id_for_the_region" {
   description = "Standard AWS ELB Account ID for the related region"
   type        = string

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -239,7 +239,7 @@ variable "auth_alb_name" {
 
 variable "auth_alb_listener_port" {
   description = "Auth ALB Listener Port"
-  default     = "4443"
+  default     = "443"
   type        = string
   sensitive   = true
 }
@@ -248,6 +248,11 @@ variable "auth_alb_listener_certificate_arn" {
   description = "Auth ALB Listener Certificate ARN"
   type        = string
   sensitive   = true
+}
+
+variable "nucleus_cloudfront_origin_hostname" {
+  description = "Hostname of the Nucleus Cloudfront origin (E.g: pds-sit.mcp.nasa.gov)"
+  type        = string
 }
 
 variable "aws_elb_account_id_for_the_region" {

--- a/terraform/variables/terraform.tfvars.dev
+++ b/terraform/variables/terraform.tfvars.dev
@@ -31,9 +31,10 @@ pds_nucleus_config_bucket_name_postfix       = "config-dev"
 pds_nucleus_default_airflow_dag_id      = "pds-basic-registry-load-use-case"
 pds_nucleus_s3_backlog_processor_dag_id = "pds-nucleus-s3-backlog-processor"
 
-cognito_user_pool_id              = "us-west-2_ABCDEFG"
-cognito_user_pool_domain          = "pds-registry"
-auth_alb_listener_certificate_arn = "arn:aws:acm:us-west-2:123456789:certificate/ca123456-abcd-abcd-1234-abcdefghi"
+cognito_user_pool_id               = "us-west-2_ABCDEFG"
+cognito_user_pool_domain           = "pds-registry"
+auth_alb_listener_certificate_arn  = "arn:aws:acm:us-west-2:123456789:certificate/ca123456-abcd-abcd-1234-abcdefghi"
+nucleus_cloudfront_origin_hostname = "pds-sit.mcp.nasa.gov"
 
 # This accountID is given by Amazon for ELBs in the us-west-2 region
 aws_elb_account_id_for_the_region = "797873946194"

--- a/terraform/variables/terraform.tfvars.test
+++ b/terraform/variables/terraform.tfvars.test
@@ -31,9 +31,10 @@ pds_nucleus_config_bucket_name_postfix       = "config-dev"
 pds_nucleus_default_airflow_dag_id      = "pds-basic-registry-load-use-case"
 pds_nucleus_s3_backlog_processor_dag_id = "pds-nucleus-s3-backlog-processor"
 
-cognito_user_pool_id              = "us-west-2_ABCDEFG"
-cognito_user_pool_domain          = "pds-registry"
-auth_alb_listener_certificate_arn = "arn:aws:acm:us-west-2:123456789:certificate/ca123456-abcd-abcd-1234-abcdefghi"
+cognito_user_pool_id               = "us-west-2_ABCDEFG"
+cognito_user_pool_domain           = "pds-registry"
+auth_alb_listener_certificate_arn  = "arn:aws:acm:us-west-2:123456789:certificate/ca123456-abcd-abcd-1234-abcdefghi"
+nucleus_cloudfront_origin_hostname = "pds-test.mcp.nasa.gov"
 
 # This accountID is given by Amazon for ELBs in the us-west-2 region
 aws_elb_account_id_for_the_region = "797873946194"


### PR DESCRIPTION
## 🗒️ Summary
Changes to use a user-friendly URL for Nucleus Auth ALB

## ⚙️ Test Data and/or Report

Successfully tested with https://pds-sit.mcp.nasa.gov/nucleus URL

## ♻️ Related Issues

[Create a user friendly URL for Nucleus Airflow UI Website #153
](https://github.com/NASA-PDS/nucleus/issues/153)

