### PR TITLE
Allow PutObjectTagging when archiving files

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -186,21 +186,23 @@
         "is_secret": false
       }
     ],
-    "terraform/terraform-modules/ecs-ecr/ecs_ecr.tf": [
+    "terraform/terraform-modules/ecs-ecr/docker/deploy-ecr-images.sh": [
       {
         "type": "AWS Sensitive Information (Experimental Plugin)",
-        "filename": "terraform/terraform-modules/ecs-ecr/ecs_ecr.tf",
+        "filename": "terraform/terraform-modules/ecs-ecr/docker/deploy-ecr-images.sh",
         "hashed_secret": "9ad897024d8c36c541d7fe84084c4e9f4df00b2a",
         "is_verified": false,
-        "line_number": 19,
+        "line_number": 4,
         "is_secret": false
-      },
+      }
+    ],
+    "terraform/terraform-modules/ecs-ecr/ecs_ecr.tf": [
       {
         "type": "Secret Keyword",
         "filename": "terraform/terraform-modules/ecs-ecr/ecs_ecr.tf",
         "hashed_secret": "957580e87fca1bd3e2acdfbae2a6c6e24a1d4ade",
         "is_verified": false,
-        "line_number": 166,
+        "line_number": 165,
         "is_secret": false
       },
       {
@@ -208,10 +210,10 @@
         "filename": "terraform/terraform-modules/ecs-ecr/ecs_ecr.tf",
         "hashed_secret": "227f2d989bdd935539c4e9bd92b8c4a5965505ac",
         "is_verified": false,
-        "line_number": 180,
+        "line_number": 179,
         "is_secret": false
       }
     ]
   },
-  "generated_at": "2025-08-05T07:38:42Z"
+  "generated_at": "2025-08-07T07:34:53Z"
 }

--- a/terraform/terraform-modules/iam/iam.tf
+++ b/terraform/terraform-modules/iam/iam.tf
@@ -244,7 +244,8 @@ data "aws_iam_policy_document" "ecs_task_role_inline_policy" {
   statement {
     effect = "Allow"
     actions = [
-      "s3:PutObject"
+      "s3:PutObject",
+      "s3:PutObjectTagging"
     ]
     resources = [
       "arn:aws:s3:::${lower(replace(var.pds_node_names[count.index], "_", "-"))}-archive*",


### PR DESCRIPTION
## 🗒️ Summary
Allow PutObjectTagging when archiving files

## ⚙️ Test Data and/or Report

Before the fix the Archie task of Nucleus basic registry loader workflow was failing as follows.
<img width="1709" height="542" alt="Screenshot 2025-08-07 at 12 25 25 AM" src="https://github.com/user-attachments/assets/99664368-31bc-4cf8-b3e0-2c22a8aeaa58" />



After the fix, the Archie task was successful as shown below.
<img width="1703" height="614" alt="Screenshot 2025-08-07 at 12 25 45 AM" src="https://github.com/user-attachments/assets/8686b08d-72d3-4a10-959c-6c07debb3c06" />


## ♻️ Related Issues
This was to resolve an new permission issue observed while archiving file.

